### PR TITLE
Add EmitWarningsOnPlaceholders("age")

### DIFF
--- a/src/backend/utils/ag_guc.c
+++ b/src/backend/utils/ag_guc.c
@@ -42,4 +42,5 @@ void define_config_params(void)
                              NULL,
                              NULL,
                              NULL);
+    EmitWarningsOnPlaceholders("age");
 }


### PR DESCRIPTION
Added EmitWarningsOnPlaceholders("age") to warn when an undefined GUC parameter is set for a placeholder named "age". Warnings are issued when PostgreSQL starts.

When PostgreSQL starts
```
2024-08-01 18:32:31.220 JST [2039799] WARNING: invalid configuration parameter name "age.invalid_parameter", removing it
```